### PR TITLE
Add RISC-V target with zero runtime capability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/uselessgoddess/zxc/issues/2
+Your prepared branch: issue-2-f4cafc8b0b38
+Your prepared working directory: /tmp/gh-issue-solver-1762341676829
+Your forked repository: konard/zxc
+Original repository (upstream): uselessgoddess/zxc
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/uselessgoddess/zxc/issues/2
-Your prepared branch: issue-2-f4cafc8b0b38
-Your prepared working directory: /tmp/gh-issue-solver-1762341676829
-Your forked repository: konard/zxc
-Original repository (upstream): uselessgoddess/zxc
-
-Proceed.

--- a/compiler/abi/Cargo.toml
+++ b/compiler/abi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "abi"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 index_vec = { version = "0.1.3" }

--- a/compiler/driver/Cargo.toml
+++ b/compiler/driver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "driver"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 cranelift = { version = "0.103" }

--- a/compiler/errors/Cargo.toml
+++ b/compiler/errors/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "errors"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 parking_lot = { version = "0.12.1" }

--- a/compiler/lexer/Cargo.toml
+++ b/compiler/lexer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lexer"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 chumsky = { version = "1.0.0-alpha.6" }

--- a/compiler/lexer/src/lib.rs
+++ b/compiler/lexer/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(let_chains, slice_ptr_len, slice_ptr_get, assert_matches, box_patterns)]
+#![feature(slice_ptr_len, slice_ptr_get, assert_matches, box_patterns)]
 #![allow(clippy::unit_arg, clippy::let_unit_value, clippy::missing_safety_doc)]
 
 #[macro_use]

--- a/compiler/lint/Cargo.toml
+++ b/compiler/lint/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lint"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 errors = { path = "../errors" }

--- a/compiler/llvm/Cargo.toml
+++ b/compiler/llvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "llvm"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 libc = "0.2.151"

--- a/compiler/macros/Cargo.toml
+++ b/compiler/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "macros"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/compiler/middle/Cargo.toml
+++ b/compiler/middle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "middle"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 arrayvec = "0.7.4"

--- a/compiler/middle/src/hir/mod.rs
+++ b/compiler/middle/src/hir/mod.rs
@@ -1454,6 +1454,11 @@ impl<'hir> HirCtx<'hir> {
             return None;
         }
 
+        // If no_main is set, don't require an entry point
+        if self.tcx.sess.opts.Z.no_main {
+            return None;
+        }
+
         let mut start_fn = None;
         for &def in self.root().defs.values() {
             if attr::contains_name(self.attrs(def), sym::start) {

--- a/compiler/middle/src/man/mod.rs
+++ b/compiler/middle/src/man/mod.rs
@@ -1,10 +1,15 @@
-use crate::{hir::Hx, mir::DefId};
+use crate::{hir::{Hx, attr}, mir::DefId, sym};
 
 pub fn compute_symbol_name(hix: Hx<'_>, def: DefId) -> String {
     let name = hix.instances[def].symbol.to_string();
 
     // possible is foreign item
     if hix.defs.get(def).is_none() {
+        return name;
+    }
+
+    // Check for no_mangle attribute
+    if attr::contains_name(hix.attrs(def), sym::no_mangle) {
         return name;
     }
 

--- a/compiler/middle/src/sess/mod.rs
+++ b/compiler/middle/src/sess/mod.rs
@@ -181,6 +181,7 @@ options! {
     temps_dir: Option<String> = (None, parse_opt_string,
         "the directory the intermediate files are written to"),
     codegen_backend: Option<String> = (None, parse_opt_string, "the codegen backend"),
+    no_main: bool = (false, parse_bool, "don't require a main function"),
 }
 
 options! {

--- a/compiler/middle/src/spec/base/mod.rs
+++ b/compiler/middle/src/spec/base/mod.rs
@@ -1,5 +1,6 @@
 pub mod linux;
 pub mod linux_gnu;
 pub mod msvc;
+pub mod none;
 pub mod windows_gnu;
 pub mod windows_msvc;

--- a/compiler/middle/src/spec/base/none.rs
+++ b/compiler/middle/src/spec/base/none.rs
@@ -1,0 +1,11 @@
+use crate::spec::{Cc, LinkerFlavor, Lld, TargetOptions};
+
+pub fn opts() -> TargetOptions {
+    TargetOptions {
+        os: "none".into(),
+        linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
+        linker: Some("rust-lld".into()),
+        executables: true,
+        ..Default::default()
+    }
+}

--- a/compiler/middle/src/spec/mod.rs
+++ b/compiler/middle/src/spec/mod.rs
@@ -395,4 +395,5 @@ supported_targets! {
     ("x86_64-pc-windows-msvc", x86_64_pc_windows_msvc),
     ("x86_64-unknown-linux-gnu", x86_64_unknown_linux_gnu),
     ("aarch64-unknown-linux-gnu", aarch64_unknown_linux_gnu),
+    ("riscv32i-unknown-none-elf", riscv32i_unknown_none_elf),
 }

--- a/compiler/middle/src/spec/targets/riscv32i_unknown_none_elf.rs
+++ b/compiler/middle/src/spec/targets/riscv32i_unknown_none_elf.rs
@@ -1,0 +1,23 @@
+use {
+    crate::spec::{base, Cc, LinkerFlavor, Lld, Target},
+    macros::target_data_layout,
+};
+
+pub fn target() -> Target {
+    let mut base = base::none::opts();
+    base.cpu = "generic-rv32".into();
+    base.linker_flavor = LinkerFlavor::Gnu(Cc::No, Lld::Yes);
+    base.linker = Some("rust-lld".into());
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &["-m", "elf32lriscv"]);
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::No, Lld::Yes), &["-m", "elf32lriscv"]);
+
+    Target {
+        triple: "riscv32i-unknown-none-elf".into(),
+        pointer_width: 32,
+        data_layout: target_data_layout!(
+            "e-m:e-p:32:32-i64:64-n32-S128"
+        ),
+        arch: "riscv32".into(),
+        options: base,
+    }
+}

--- a/compiler/middle/src/symbol.rs
+++ b/compiler/middle/src/symbol.rs
@@ -121,6 +121,7 @@ macros::symbols! {
         link,
         main,
         name,
+        no_mangle,
         offset,
         start,
     }

--- a/experiments/test_riscv_no_main.zxc
+++ b/experiments/test_riscv_no_main.zxc
@@ -1,0 +1,9 @@
+#[no_mangle]
+fn my_function() -> i32 {
+    42
+}
+
+#[no_mangle]
+fn another_function(x: i32, y: i32) -> i32 {
+    x + y
+}

--- a/experiments/test_riscv_with_main.zxc
+++ b/experiments/test_riscv_with_main.zxc
@@ -1,0 +1,8 @@
+#[no_mangle]
+fn helper() -> i32 {
+    100
+}
+
+fn main() -> i32 {
+    helper()
+}


### PR DESCRIPTION
## Summary

This PR implements RISC-V target support with zero runtime capability as requested in issue #2.

### Features Implemented

✅ **RISC-V 32-bit target triple** (`riscv32i-unknown-none-elf`)
   - Supports compilation to `bin`, `dylib`, and `staticlib` output types
   - Uses bare metal environment (os = "none")  
   - Configured for RISC-V 32-bit architecture with appropriate data layout
   - Suitable for embedded systems and zero-runtime environments

✅ **Optional entry point** via `-Z no_main` flag
   - When enabled, `entry_fn` returns `None` 
   - Allows compilation without `main` or `#[start]` functions
   - Enables building libraries and runtime-less code

✅ **`#[no_mangle]` attribute support**
   - Functions marked with `#[no_mangle]` preserve their original symbol names
   - Symbol mangling is skipped for such functions
   - Essential for FFI and bare metal programming

## Implementation Details

### New Files
- `compiler/middle/src/spec/base/none.rs` - Bare metal base configuration
- `compiler/middle/src/spec/targets/riscv32i_unknown_none_elf.rs` - RISC-V target specification
- `experiments/test_riscv_*.zxc` - Test files demonstrating functionality

### Modified Files
- `compiler/middle/src/symbol.rs` - Added `no_mangle` symbol
- `compiler/middle/src/man/mod.rs` - Skip mangling for `#[no_mangle]` functions
- `compiler/middle/src/hir/mod.rs` - Respect `no_main` flag in `entry_fn()`
- `compiler/middle/src/sess/mod.rs` - Added `-Z no_main` compiler option
- `compiler/middle/src/spec/mod.rs` - Registered new RISC-V target

### Additional Changes
- Updated project to Rust 2024 edition for compatibility with let chains
- Removed stabilized feature flags

## Usage Examples

### Compile for RISC-V with no main function
```bash
zxc --target riscv32i-unknown-none-elf -Z no_main --crate-type staticlib input.zxc
```

### Use `#[no_mangle]` attribute
```rust
#[no_mangle]
fn my_function() -> i32 {
    42
}
```

## Testing

Test files have been added to the `experiments/` directory demonstrating:
1. Zero-runtime code with `#[no_mangle]` functions
2. Mixed code with both `#[no_mangle]` functions and a `main` entry point

## Related

Fixes #2

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)